### PR TITLE
bug fix: CSV exporter cant's output multiple line columns

### DIFF
--- a/src/Goodby/CSV/Export/Standard/CsvFileObject.php
+++ b/src/Goodby/CSV/Export/Standard/CsvFileObject.php
@@ -51,7 +51,13 @@ class CsvFileObject extends SplFileObject
         array_unshift($arguments, $fp);
         call_user_func_array('fputcsv', $arguments);
         rewind($fp);
-        $line = fgets($fp);
+
+        $line = '';
+
+        while ( feof($fp) === false ) {
+            $line .= fgets($fp);
+        }
+
         fclose($fp);
 
         /**

--- a/src/Goodby/CSV/Export/Tests/Standard/Join/ExporterTest.php
+++ b/src/Goodby/CSV/Export/Tests/Standard/Join/ExporterTest.php
@@ -167,4 +167,22 @@ class ExporterTest extends \PHPUnit_Framework_TestCase
         $expectedCount = "a,b,c\r\n1,2,3\r\n";
         $this->assertSame($expectedCount, $output);
     }
+
+    public function test_multiple_line_columns()
+    {
+        $csv = 'vfs://output/multiple-lines.csv';
+        $this->assertFileNotExists($csv);
+
+        $config = new ExporterConfig();
+        $config->setNewline("\r\n");
+        $exporter = new Exporter($config);
+
+        $exporter->export($csv, array(
+            array("line1\r\nline2\r\nline3", "single-line"),
+            array("line1\r\nline2\r\nline3", "single-line"),
+            array("line1\r\nline2\r\nline3", "single-line"),
+        ));
+
+        $this->assertFileEquals(__DIR__.'/csv_files/multiple-lines.csv', $csv);
+    }
 }

--- a/src/Goodby/CSV/Export/Tests/Standard/Join/csv_files/multiple-lines.csv
+++ b/src/Goodby/CSV/Export/Tests/Standard/Join/csv_files/multiple-lines.csv
@@ -1,0 +1,9 @@
+"line1
+line2
+line3",single-line
+"line1
+line2
+line3",single-line
+"line1
+line2
+line3",single-line


### PR DESCRIPTION
How to reproduce

``` php
$config = new ExporterConfig();
$exporter = new Exporter($config);

$exporter->export($csv, array(
    array("line1\r\nline2\r\nline3"),
    array("line1\r\nline2\r\nline3"),
    array("line1\r\nline2\r\nline3"),
));
```

Expected CSV Output

```
"line1
line2
line3"
"line1
line2
line3"
"line1
line2
line3"
```

Actual Behavior

```
"line1
"line1
"line1
```
