### PR TITLE
setlocale() call issues PHP Warning on CentOS 6.4, PHP 5.4.13

### DIFF
--- a/src/Goodby/CSV/Import/Standard/Lexer.php
+++ b/src/Goodby/CSV/Import/Standard/Lexer.php
@@ -57,6 +57,7 @@ class Lexer implements LexerInterface
             $interpreter->interpret($line);
         }
 
-        setlocale(LC_ALL, $originalLocale); // Reset locale
+        parse_str(str_replace(';', '&', $originalLocale), $locale_array);
+        setlocale(LC_ALL, $locale_array); // Reset locale
     }
 }


### PR DESCRIPTION
This fixes a PHP Warning I'm getting with PHP 5.4.13:

```
setlocale(): Specified locale name is too long
```

Sorry, I'm not sure if this is portable. It should be tested on Windows and OS X, but I don't have those.

Operating system: up-to-date CentOS release 6.4 (Final)

See also: http://stackoverflow.com/questions/16110866/why-do-i-get-this-php-warning-setlocale-specified-locale-name-is-too-long
