### PR TITLE
Added ability to ignore header rows by importer

### DIFF
--- a/src/Goodby/CSV/Import/Standard/Lexer.php
+++ b/src/Goodby/CSV/Import/Standard/Lexer.php
@@ -33,12 +33,13 @@ class Lexer implements LexerInterface
     {
         ini_set('auto_detect_line_endings', true); // For mac's office excel csv
 
-        $delimiter   = $this->config->getDelimiter();
-        $enclosure   = $this->config->getEnclosure();
-        $escape      = $this->config->getEscape();
-        $fromCharset = $this->config->getFromCharset();
-        $toCharset   = $this->config->getToCharset();
-        $flags       = $this->config->getFlags();
+        $delimiter      = $this->config->getDelimiter();
+        $enclosure      = $this->config->getEnclosure();
+        $escape         = $this->config->getEscape();
+        $fromCharset    = $this->config->getFromCharset();
+        $toCharset      = $this->config->getToCharset();
+        $flags          = $this->config->getFlags();
+        $ignoreHeader   = $this->config->getIgnoreHeaderLine();
 
         if ( $fromCharset === null ) {
             $url = $filename;
@@ -53,7 +54,10 @@ class Lexer implements LexerInterface
         $originalLocale = setlocale(LC_ALL, '0'); // Backup current locale
         setlocale(LC_ALL, 'en_US.UTF-8');
 
-        foreach ( $csv as $line ) {
+        foreach ( $csv as $lineNumber => $line ) {
+            if ($ignoreHeader && $lineNumber == 0) {
+                continue;
+            }
             $interpreter->interpret($line);
         }
 

--- a/src/Goodby/CSV/Import/Standard/LexerConfig.php
+++ b/src/Goodby/CSV/Import/Standard/LexerConfig.php
@@ -40,6 +40,11 @@ class LexerConfig
     private $flags = SplFileObject::READ_CSV;
 
     /**
+     * @var bool
+     */
+    private $ignoreHeaderLine = false;
+
+    /**
      * Set delimiter
      * @param string $delimiter
      * @return LexerConfig
@@ -158,5 +163,23 @@ class LexerConfig
     public function getFlags()
     {
         return $this->flags;
+    }
+
+    /**
+     * @param $ignoreHeaderLine
+     * @return $this
+     */
+    public function setIgnoreHeaderLine($ignoreHeaderLine)
+    {
+        $this->ignoreHeaderLine = $ignoreHeaderLine;
+        return $this;
+    }
+
+    /**
+     * @return boolean
+     */
+    public function getIgnoreHeaderLine()
+    {
+        return $this->ignoreHeaderLine;
     }
 }

--- a/src/Goodby/CSV/Import/Tests/Standard/Join/LexerTest.php
+++ b/src/Goodby/CSV/Import/Tests/Standard/Join/LexerTest.php
@@ -122,4 +122,30 @@ class LexerTest extends \PHPUnit_Framework_TestCase
             array("16", "スティック型", "carot@eample.com"),
         ), $csvContents);
     }
+
+    public function test_ignore_header()
+    {
+        $csvFilename = CSVFiles::getIssue5CSV();
+
+        $config = new LexerConfig();
+        $config
+          ->setIgnoreHeaderLine(true)
+          ->setToCharset('UTF-8')
+          ->setFromCharset('UTF-8');
+
+        $lexer = new Lexer($config);
+
+        $interpreter = new Interpreter();
+        $interpreter->addObserver(function(array $columns) use (&$csvContents) {
+            $csvContents[] = $columns;
+        });
+
+        $lexer->parse($csvFilename, $interpreter);
+        $this->assertSame(array(
+            array("1", "スティック型クリーナ", "alice_updated@example.com"),
+            array("2", "bob", "bob@example.com"),
+            array("14", "スティック型クリーナ", "tho@eample.com"),
+            array("16", "スティック型", "carot@eample.com"),
+        ), $csvContents);
+    }
 }

--- a/src/Goodby/CSV/Import/Tests/Standard/Unit/LexerConfigTest.php
+++ b/src/Goodby/CSV/Import/Tests/Standard/Unit/LexerConfigTest.php
@@ -51,4 +51,11 @@ class LexerConfigTest extends \PHPUnit_Framework_TestCase
         $flags = (SplFileObject::READ_AHEAD | SplFileObject::SKIP_EMPTY | SplFileObject::READ_CSV);
         $this->assertSame($flags, $config->getFlags());
     }
+
+    public function testIgnoreHeaderLine()
+    {
+        $config = new LexerConfig();
+        $this->assertSame(false, $config->getIgnoreHeaderLine());
+        $this->assertSame(true, $config->setIgnoreHeaderLine(true)->getIgnoreHeaderLine());
+    }
 }


### PR DESCRIPTION
I often have needed to ignore the first 'header' row in a csv file. This is often difficult to code around using a callback.

This adds a config which defaults to false to maintain BC.

If this config is set than the first line of the parser will be skipped from adding to the result set.
