### PR TITLE
Remove redundant check of valid callable.

### DIFF
--- a/src/Goodby/CSV/Import/Standard/Interpreter.php
+++ b/src/Goodby/CSV/Import/Standard/Interpreter.php
@@ -84,8 +84,6 @@ class Interpreter implements InterpreterInterface
      */
     private function delegate($observer, $line)
     {
-        $this->checkCallable($observer);
-
         call_user_func($observer, $line);
     }
 


### PR DESCRIPTION
Currently the validity of the callable is checked when the callable is added, but also on every row iteration.
This PR removes the redundancy.
