### PR TITLE
Fix issue with PHP empty() function checking the status of the first line

### DIFF
--- a/src/Goodby/CSV/Import/Standard/Lexer.php
+++ b/src/Goodby/CSV/Import/Standard/Lexer.php
@@ -57,7 +57,7 @@ class Lexer implements LexerInterface
         setlocale(LC_ALL, 'en_US.UTF-8');
 
         foreach ( $csv as $lineNumber => $line ) {
-            if ($ignoreHeader && $lineNumber == 0 || (count($line) === 1 && empty($line[0]))) {
+            if ($ignoreHeader && $lineNumber == 0 || (count($line) === 1 && trim($line[0]) === '')) {
                 continue;
             }
             $interpreter->interpret($line);


### PR DESCRIPTION
The goal of the code was to skip empty padding row between the header and the body. The previous code skips valid first row values:

```
Numbers
0
1
2
3
```

Only 1, 2, 3 would be processed. This fixes that.