### PR TITLE
Add support for named columns in CSV.

### DIFF
--- a/src/Goodby/CSV/Import/Protocol/InterpreterInterface.php
+++ b/src/Goodby/CSV/Import/Protocol/InterpreterInterface.php
@@ -12,4 +12,10 @@ interface InterpreterInterface
      * @return void
      */
     public function interpret($line);
+
+    /**
+     * @param $line
+     * @return void
+     */
+    public function setHeaders($line);
 }

--- a/src/Goodby/CSV/Import/Standard/Interpreter.php
+++ b/src/Goodby/CSV/Import/Standard/Interpreter.php
@@ -27,6 +27,11 @@ class Interpreter implements InterpreterInterface
     private $strict = true;
 
     /**
+     * @var array
+     */
+    private $headers = array();
+
+    /**
      * interpret line
      *
      * @param $line
@@ -41,7 +46,29 @@ class Interpreter implements InterpreterInterface
             throw new InvalidLexicalException('line is must be array');
         }
 
+        if (!empty($this->headers)) {
+            $line = array_combine($this->headers, $line);
+        }
+
         $this->notify($line);
+    }
+
+    /**
+     * set column headers
+     *
+     * @param $line
+     * @return void
+     * @throws \Goodby\CSV\Import\Protocol\Exception\InvalidLexicalException
+     */
+    public function setHeaders($line)
+    {
+        $this->checkRowConsistency($line);
+
+        if (!is_array($line)) {
+            throw new InvalidLexicalException('line is must be array');
+        }
+
+        $this->headers = $line;
     }
 
     public function unstrict()

--- a/src/Goodby/CSV/Import/Standard/Lexer.php
+++ b/src/Goodby/CSV/Import/Standard/Lexer.php
@@ -42,6 +42,7 @@ class Lexer implements LexerInterface
         $toCharset      = $this->config->getToCharset();
         $flags          = $this->config->getFlags();
         $ignoreHeader   = $this->config->getIgnoreHeaderLine();
+        $namedColumns   = $this->config->getUseNamedColumns();
 
         if ( $fromCharset === null ) {
             $url = $filename;
@@ -58,6 +59,10 @@ class Lexer implements LexerInterface
 
         foreach ( $csv as $lineNumber => $line ) {
             if ($ignoreHeader && $lineNumber == 0 || (count($line) === 1 && trim($line[0]) === '')) {
+                continue;
+            }
+            else if ($namedColumns && $lineNumber == 0) {
+                $interpreter->setHeaders($line);
                 continue;
             }
             $interpreter->interpret($line);

--- a/src/Goodby/CSV/Import/Standard/LexerConfig.php
+++ b/src/Goodby/CSV/Import/Standard/LexerConfig.php
@@ -45,6 +45,11 @@ class LexerConfig
     private $ignoreHeaderLine = false;
 
     /**
+     * @var bool
+     */
+    private $useNamedColumns = false;
+
+    /**
      * Set delimiter
      * @param string $delimiter
      * @return LexerConfig
@@ -181,5 +186,24 @@ class LexerConfig
     public function getIgnoreHeaderLine()
     {
         return $this->ignoreHeaderLine;
+    }
+
+    /**
+     * Enable named columns. getIgnoreHeaderLine() must be false to use this.
+     * @param $useNamedColumns
+     * @return $this
+     */
+    public function setUseNamedColumns($useNamedColumns)
+    {
+        $this->useNamedColumns = $useNamedColumns;
+        return $this;
+    }
+
+    /**
+     * @return boolean
+     */
+    public function getUseNamedColumns()
+    {
+        return $this->useNamedColumns;
     }
 }


### PR DESCRIPTION
Make CSV line arrays use column names as keys. Simplifies inserting into
databases or just accessing CSV columns by name.
