### PR TITLE
Use symfony polyfill for mbstring php extension

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
     ],
     "require": {
         "php": ">=5.3.2",
-        "ext-mbstring": "*"
+        "symfony/polyfill-mbstring": "^1.0"
     },
     "require-dev": {
         "phpunit/phpunit": "3.7.*",


### PR DESCRIPTION
It allows to use this library without the mbstring extension installed it will do nothing when mbstring extension is available.