### PR TITLE
Fix travis ci runner

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,12 +14,10 @@ matrix:
         dist: trusty
       - php: 7.1
         dist: trusty
-      - php: 7.2
-        dist: trusty
-# allow 7.2 to fail as phpunit 3 not working correctly with php 7.2
-    allow_failures:
-      - php: 7.2
-        dist: trusty
+# PHP 7.2 can currently not been tested because of incompatibility with PHPUnit 3
+# atleast PHPUnit 7.0 would be needed which don't support 5.3
+#      - php: 7.2
+#        dist: trusty
 
 before_script:
   - ./scripts/bundle-devtools.sh .

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,22 +6,20 @@ matrix:
         dist: precise
       - php: 5.4
         dist: trusty
-        sudo: required
       - php: 5.5
         dist: trusty
-        sudo: required
       - php: 5.6
         dist: trusty
-        sudo: required
       - php: 7.0
         dist: trusty
-        sudo: required
       - php: 7.1
         dist: trusty
-        sudo: required
       - php: 7.2
         dist: trusty
-        sudo: required
+# allow 7.2 to fail as phpunit 3 not working correctly with php 7.2
+    allow_failures:
+      - php: 7.2
+        dist: trusty
 
 before_script:
   - ./scripts/bundle-devtools.sh .

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,24 @@
 language: php
-php:
-  - 5.3
-  - 5.4
-  - 5.5
-  - 5.6
+
+matrix:
+    include:
+      - php: 5.3
+        dist: precise
+      - php: 5.4
+        dist: trusty
+        sudo: required
+      - php: 5.5
+        dist: trusty
+        sudo: required
+      - php: 5.6
+        dist: trusty
+        sudo: required
+      - php: 7.0
+        dist: trusty
+        sudo: required
+      - php: 7.1
+        dist: trusty
+        sudo: required
 
 before_script:
   - ./scripts/bundle-devtools.sh .

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,6 +19,9 @@ matrix:
       - php: 7.1
         dist: trusty
         sudo: required
+      - php: 7.2
+        dist: trusty
+        sudo: required
 
 before_script:
   - ./scripts/bundle-devtools.sh .

--- a/composer.json
+++ b/composer.json
@@ -24,9 +24,9 @@
     },
     "require-dev": {
         "phpunit/phpunit": "3.7.*",
-        "mockery/mockery": ">=0.7.2",
-        "suin/php-expose": ">=1.0",
-        "mikey179/vfsStream": ">=1.1.0"
+        "mockery/mockery": "^0.7.2",
+        "suin/php-expose": "^1.0",
+        "mikey179/vfsStream": "^1.1"
     },
     "autoload": {
         "psr-0": {

--- a/scripts/bundle-devtools.sh
+++ b/scripts/bundle-devtools.sh
@@ -33,4 +33,4 @@ wget http://getcomposer.org/composer.phar
 
 chmod +x composer.phar
 
-./composer.phar install --dev
+./composer.phar install


### PR DESCRIPTION
This fix the current test setup by using the correct versions of the dev dependencies.
Also added the 7.0, 7.1, 7.2 Versions of PHP to the test matrix. but 7.2 currently seems not working with phpunit 3 and not sure which phpunit version support 5.3 to 7.2 so I currently added to allow failures.