### PR TITLE
Add compatibility for PHP 8.1

### DIFF
--- a/src/Goodby/CSV/Export/Standard/CsvFileObject.php
+++ b/src/Goodby/CSV/Export/Standard/CsvFileObject.php
@@ -47,7 +47,8 @@ class CsvFileObject extends SplFileObject
      * @param useless  $escape  THIS PARAM IS UNSED, BUT REQUIRED EXISTS, see https://bugs.php.net/bug.php?id=68479 and https://github.com/goodby/csv/issues/56
      * @return int|void
      */
-    public function fputcsv($fields, $delimiter = null, $enclosure = null, $escape = null)
+    #[ReturnTypeWillChange]
+    public function fputcsv($fields, $delimiter = null, $enclosure = null, $escape = null, $eol = null)
     {
         // Temporary output a line to memory to get line as string
         $fp = fopen('php://temp', 'w+');


### PR DESCRIPTION
Additonal parameter was added and fputcsv has a returntype of `int|false` now. For cross support php version support I added the #[ReturnTypeWillChange] attribute.

Example:

Errors:

```bash
php -r 'class CsvFileObject extends SplFileObject
{
public function fputcsv($fields, $delimiter = null, $enclosure = null, $escape = null, $eol = null){}
}'
```

> PHP Deprecated:  Return type of CsvFileObject::fputcsv($fields, $delimiter = null, $enclosure = null, $escape = null, $eol = null) should either be compatible with SplFileObject::fputcsv(array $fields, string $separator = ",", string $enclosure = "\"", string $escape = "\\", string $eol = "\n"): int|false, or the #[ReturnTypeWillChange] attribute should be used to temporarily suppress the notice in Command line code on line 3

Fix:

```bash
php -r 'class CsvFileObject extends SplFileObject
{
#[ReturnTypeWillChange]
public function fputcsv($fields, $delimiter = null, $enclosure = null, $escape = null, $eol = null){}
}'
```