### PR TITLE
Update to latest Composer format

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,7 @@
         "phpunit/phpunit": "3.7.*",
         "mockery/mockery": "^0.7.2",
         "suin/php-expose": "^1.0",
-        "mikey179/vfsStream": "^1.1"
+        "mikey179/vfsstream": "^1.1"
     },
     "autoload": {
         "psr-0": {


### PR DESCRIPTION
An error occurs when running `composer install --dev` with Composer version 2 or later.

```
In RootPackageLoader.php line 160:

  require-dev.mikey179/vfsStream is invalid, it should not contain uppercase characters. Please use mikey179/vfsstream instead.
```

my env
- PHP 8.2.9
- Composer 2.5.8